### PR TITLE
Add Support for HDR

### DIFF
--- a/code/core/Color.cpp
+++ b/code/core/Color.cpp
@@ -3,9 +3,9 @@
 #include <string>
 
 Color::Color(float r, float g, float b) {
-  r_ = ColorCompClamp(r);
-  g_ = ColorCompClamp(g);
-  b_ = ColorCompClamp(b);
+  r_ = r;
+  g_ = g;
+  b_ = b;
 }
 
 float Color::Lum() const {

--- a/code/core/Color.cpp
+++ b/code/core/Color.cpp
@@ -8,6 +8,10 @@ Color::Color(float r, float g, float b) {
   b_ = ColorCompClamp(b);
 }
 
+float Color::Lum() const {
+  return 0.3f*r_ + 0.6f*g_ + 0.1f*b_;
+}
+
 float ColorCompClamp(float comp) {
   if (comp < 0) return 0;
   if (comp > 1) return 1;

--- a/code/core/Color.h
+++ b/code/core/Color.h
@@ -16,6 +16,10 @@ class Color {
     float R() const { return r_; }
     float G() const { return g_; }
     float B() const { return b_; }
+
+    /// Compute the luminance of this Color, as
+    /// 0.3r + 0.6g + 0.1b
+    float Lum() const;
 };
 
 /// Clamp a color component to the range [0,1]

--- a/code/image/CMakeLists.txt
+++ b/code/image/CMakeLists.txt
@@ -1,3 +1,3 @@
-add_library(image Image.cpp)
+add_library(image ToneMap.cpp Image.cpp)
 
 target_include_directories(image PUBLIC ${PROJECT_SOURCE_DIR})

--- a/code/image/Image.cpp
+++ b/code/image/Image.cpp
@@ -121,9 +121,9 @@ uint8_t* Image::AsBytes() const {
   for (int y = 0; y < height_; y++) {
     for (int x = 0; x < width_; x++) {
       Color c = pixels_[y * width_ + x];
-      data[4 * (y * width_ + x)] = uint8_t(c.R() * 255 + 0.5);
-      data[4 * (y * width_ + x) + 1] = uint8_t(c.G() * 255 + 0.5);
-      data[4 * (y * width_ + x) + 2] = uint8_t(c.B() * 255 + 0.5);
+      data[4 * (y * width_ + x)] = uint8_t(ColorCompClamp(c.R()) * 255 + 0.5);
+      data[4 * (y * width_ + x) + 1] = uint8_t(ColorCompClamp(c.G()) * 255 + 0.5);
+      data[4 * (y * width_ + x) + 2] = uint8_t(ColorCompClamp(c.B()) * 255 + 0.5);
       data[4 * (y * width_ + x) + 3] = 255;
     }
   }

--- a/code/image/Image.cpp
+++ b/code/image/Image.cpp
@@ -53,7 +53,7 @@ void Image::Write(const std::string& filename) const {
     Log::Error("output image file name '" + filename + "' is too short - nothing written");
     return;
   }
-
+  Log::Debug("Average luminance of image is " + std::to_string(AvgLum()));
   uint8_t* data = AsBytes();
 
   // Infer the format to write in based on the end of the filename
@@ -128,4 +128,22 @@ uint8_t* Image::AsBytes() const {
     }
   }
   return data;
+}
+
+float Image::AvgLum() const {
+  float total_lum = 0.0f;
+  int num_pixels = width_ * height_;
+
+  // An Image with no pixels has 0 average luminance (I guess)
+  if (num_pixels <= 0) {
+    return 0.0f;
+  }
+
+  for (int y = 0; y < height_; y++) {
+    for (int x = 0; x < width_; x++) {
+      total_lum += pixels_[y * width_ + x].Lum();
+    }
+  }
+
+  return total_lum / num_pixels;
 }

--- a/code/image/Image.cpp
+++ b/code/image/Image.cpp
@@ -4,6 +4,7 @@
 #include <cctype> // for tolower()
 
 #include "stb_image/stb_image_write.h"
+#include "image/ToneMap.h"
 #include "logging/Log.h"
 
 Image::Image(int width, int height) {
@@ -121,9 +122,10 @@ uint8_t* Image::AsBytes() const {
   for (int y = 0; y < height_; y++) {
     for (int x = 0; x < width_; x++) {
       Color c = pixels_[y * width_ + x];
-      data[4 * (y * width_ + x)] = uint8_t(ColorCompClamp(c.R()) * 255 + 0.5);
-      data[4 * (y * width_ + x) + 1] = uint8_t(ColorCompClamp(c.G()) * 255 + 0.5);
-      data[4 * (y * width_ + x) + 2] = uint8_t(ColorCompClamp(c.B()) * 255 + 0.5);
+      c = ToneMapBasicClamp(c);
+      data[4 * (y * width_ + x)] = uint8_t(c.R() * 255 + 0.5);
+      data[4 * (y * width_ + x) + 1] = uint8_t(c.G() * 255 + 0.5);
+      data[4 * (y * width_ + x) + 2] = uint8_t(c.B() * 255 + 0.5);
       data[4 * (y * width_ + x) + 3] = 255;
     }
   }

--- a/code/image/Image.h
+++ b/code/image/Image.h
@@ -40,6 +40,9 @@ class Image {
     /// in the range [0, 255], for RGBA
     /// Returns a pointer to a dynamically allocated list of bytes
     uint8_t* AsBytes() const;
+
+    /// Get the average luminance of the samples in this image
+    float AvgLum() const;
 };
 
 #endif

--- a/code/image/ToneMap.cpp
+++ b/code/image/ToneMap.cpp
@@ -1,0 +1,11 @@
+#include "image/ToneMap.h"
+
+#include "core/Color.h"
+
+Color ToneMapBasicClamp(const Color& c) {
+  return Color(ColorCompClamp(c.R()), ColorCompClamp(c.G()), ColorCompClamp(c.B()));
+}
+
+Color ToneMapAvgLumScale(const Color& c, float avg_lum, float alpha) {
+  return alpha / avg_lum * c;
+}

--- a/code/image/ToneMap.h
+++ b/code/image/ToneMap.h
@@ -1,0 +1,10 @@
+#ifndef IMAGE_TONE_MAP_H_
+#define IMAGE_TONE_MAP_H_
+
+#include "core/Color.h"
+
+  Color ToneMapBasicClamp(const Color& c);
+
+  Color ToneMapAvgLumScale(const Color& c, float avg_lum, float alpha);
+
+#endif

--- a/tests/core/test_Color.h
+++ b/tests/core/test_Color.h
@@ -1,0 +1,20 @@
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/catch_approx.hpp>
+
+#include "core/Color.h"
+
+using Catch::Approx;
+
+TEST_CASE("Color luminance") {
+  Color red(1, 0, 0);
+  Color green(0, 1, 0);
+  Color blue(0, 0, 1);
+  Color black(0, 0, 0);
+  Color white(1, 1, 1);
+
+  REQUIRE(red.Lum() == Approx(0.3f));
+  REQUIRE(green.Lum() == Approx(0.6f));
+  REQUIRE(blue.Lum() == Approx(0.1f));
+  REQUIRE(black.Lum() == Approx(0.0f));
+  REQUIRE(white.Lum() == Approx(1.0f));
+}

--- a/tests/image/test_ToneMap.cpp
+++ b/tests/image/test_ToneMap.cpp
@@ -1,0 +1,14 @@
+#include <catch2/catch_test_macros.hpp>
+#include <catch2/catch_approx.hpp>
+
+#include "core/Color.h"
+#include "image/ToneMap.h"
+
+TEST_CASE("Basic clamp tone map") {
+  Color c(100.0f, -2.0f, 0.3f);
+  c = ToneMapBasicClamp(c);
+  REQUIRE(c.R() == Approx(1.0f));
+  REQUIRE(c.G() == Approx(0.0f));
+  REQUIRE(c.B() == Approx(0.3f));
+}
+

--- a/tests/run_tests.cpp
+++ b/tests/run_tests.cpp
@@ -8,3 +8,5 @@
 
 #include "geom/test_Circle.h"
 #include "geom/test_Ellipse.h"
+
+#include "image/test_ToneMap.cpp"

--- a/tests/run_tests.cpp
+++ b/tests/run_tests.cpp
@@ -4,6 +4,7 @@
 // Include all of test files, which are all
 // header files using Catch2 test macros
 #include "core/test_Point3.h"
+#include "core/test_Color.h"
 
 #include "geom/test_Circle.h"
 #include "geom/test_Ellipse.h"


### PR DESCRIPTION
Closes #42 in preparation for more HDR features in the future.

HDR is "high dynamic range". Instead of clamping color components to the range `[0;1]` during computation, we now let them vary freely as floats. Then, after we've gathered all of our samples, we apply a series of *tone maps* to the samples to transform them into the image that we'd like. The tone map `ToneMapBasicClamp` is identical to what we were doing before -- it just clamps each component of each color to the range `[0;1]`. So ideally these changes don't change the output images at all, but they make supporting all sorts of different tone maps possible in the future.

Ideas for tone map commands and their effects:
- `tm_basic_clamp` The basic clamp that we're using here
- `tm_avg_lum_scale: alpha` A tone map that scales colors based on the average luminance of the picture while in HDR form. Implemented with `ToneMapAvgLumScale` (see the presentation linked in #42)
- `tm_red_green_colorblind` A tone map that simulates red-green colorblindness. May need to take some sorts of parameters
- `tm_bloom` A tone map that adds bloom to the image (#43). Will almost certainly need some parameters, maybe gaussian width