### PR TITLE
[#69] Add a BUILD_TESTS option to CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,11 @@ cmake_minimum_required(VERSION 3.10)
 
 project(RayTracer)
 
+option(BUILD_TESTS "Should the tests be included in the build process?
+                   If you'd just like to run the code, this should be
+                   set to OFF. If it's set to ON, the Catch2 package is
+                   required." OFF)
+
 set(CODE_DIR ${PROJECT_SOURCE_DIR}/code)
 set(TESTS_DIR ${PROJECT_SOURCE_DIR}/tests)
 set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
@@ -9,4 +14,6 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR})
 include_directories(${CODE_DIR})
 add_subdirectory(${CODE_DIR})
 
-add_subdirectory(${TESTS_DIR})
+if (BUILD_TESTS)
+  add_subdirectory(${TESTS_DIR})
+endif()


### PR DESCRIPTION
Fixes #69.

Adds a BUILD_TESTS option to CMake. This defaults to OFF. If it's set to ON, then tests are compiled with the main program. If it's set to OFF, then tests are ignored, and Catch2 isn't required.

From the command line, this option can be turned on with `-DBUILD_TESTS=ON`.