### PR TITLE
Define an M_PI constant if it's not already defined

### DIFF
--- a/code/raygen/ViewFrame.cpp
+++ b/code/raygen/ViewFrame.cpp
@@ -9,6 +9,11 @@
 #include "logging/Log.h"
 #include "raygen/PixelTraceData.h"
 
+// Some <cmath> implementations define this constant, some don't
+#ifndef M_PI
+constexpr double M_PI = 3.1415926535897932384626;
+#endif
+
 float ViewFrame::EyeToFrameDistance() const {
   // Solving the equation tan(half_angle_fov_) = (height_ / 2) / distance
   return (float)height_ / (2 * tanf(half_angle_fov_ * M_PI / 180.0));


### PR DESCRIPTION
Fixes #32.

Apparently some implementations of the cmath library define this constant, but others don't. So if it's not defined, just define it with a reasonable value and make it a `constexpr`.

With this change, the project is compiling and running with the Visual C++ compiler on my Windows machine.